### PR TITLE
Keyspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ SliderButton(
 
 There are several options that allow for more control:
 
-| Properties            | Default           | Description                                                            |
-| --------------------- | ----------------- | ---------------------------------------------------------------------- |
+| Properties          | Default           | Description                                                            |
+|---------------------| ----------------- |------------------------------------------------------------------------|
 | `action`            | null              | (required) Define an action after slidding a button and return boolean |
+| `buttonKey`         | null              | Can be used to specify a custom key. Useful for using dynamic labels.  |
 | `child`             | null              | For more customizable button add your own widget                       |
 | `vibrationFlag`     | false             | controls vibration on successful dismissed                             |
 | `height`            | null ?? 70        | Gives a height to a widget                                             |

--- a/lib/src/slider.dart
+++ b/lib/src/slider.dart
@@ -44,6 +44,8 @@ class SliderButton extends StatefulWidget {
 
   final bool disable;
 
+  final Key? buttonKey;
+
   SliderButton({
     required this.action,
     this.radius = 100,
@@ -64,6 +66,7 @@ class SliderButton extends StatefulWidget {
     this.icon,
     this.dismissThresholds = 0.75,
     this.disable = false,
+    this.buttonKey,
   }) : assert((buttonSize ?? 60) <= (height));
 
   @override
@@ -139,7 +142,7 @@ class _SliderButtonState extends State<SliderButton> {
                     ),
                   )
                 : Dismissible(
-                    key: UniqueKey(),
+                    key: widget.buttonKey ?? UniqueKey(),
                     direction: DismissDirection.startToEnd,
                     dismissThresholds: {
                       DismissDirection.startToEnd: widget.dismissThresholds

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slider_button
 description: Customizable slider button widget for activating/deactivating some event.
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/anirudhsharma392/Slider-Button
 
 environment:


### PR DESCRIPTION
Add the ability to specify custom non-unique keys on the button. Useful for dynamic labels, where a `UniqueKey` destroys interactivity by forcing Flutter to rebuild the widget continuously.